### PR TITLE
Fixes #14, removed CommandEnv from refresh config struct

### DIFF
--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -197,7 +197,6 @@ func startRefresh(publicPathEnv string, ctx context.Context) (*refresh.Manager, 
 		BuildDelay:         c.BuildDelay,
 		BinaryName:         c.BinaryName,
 		CommandFlags:       c.CommandFlags,
-		CommandEnv:         c.CommandEnv,
 		EnableColors:       c.EnableColors,
 		LogName:            c.LogName,
 	}


### PR DESCRIPTION
Please refer to #14 for why this PR is needed.

I ran the tests inside `cmd/` and they passed, however I just wanted to get this working so I haven't done much else to ensure things work.